### PR TITLE
Fix IAB on Android 11+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.example.android.trivialdrivesample"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,10 +19,16 @@
     android:versionCode="3"
     android:versionName="1.3" >
 
-    <uses-sdk android:targetSdkVersion="15" />
-
     <!-- VERY IMPORTANT! Don't forget this permission, or in-app billing won't work. -->
     <uses-permission android:name="com.farsitel.bazaar.permission.PAY_THROUGH_BAZAAR" />
+
+    <queries>
+        <package android:name="com.farsitel.bazaar" />
+        <intent>
+            <action android:name="ir.cafebazaar.pardakht.InAppBillingService.BIND" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
 
     <application
         android:icon="@drawable/ic_launcher"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.4'
     }
 }
 


### PR DESCRIPTION
Fix Android >= 11 (api >=30) inAppBilling Error:

`Billing service unavailable on device. (response: 3:Billing Unavailable)`

When manually install .apk file of your applications (not Install inside MarketApp)